### PR TITLE
default sjsconfig to {}

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -19,7 +19,7 @@ interface FactoryOutput {
 /*
 	This code looks a lot better with async functions...
 */
-export function createFactory(sjsconfig: PluginOptions, _resolve: ResolveFunction, _fetch: FetchFunction): Promise<FactoryOutput> {
+export function createFactory(sjsconfig: PluginOptions = {}, _resolve: ResolveFunction, _fetch: FetchFunction): Promise<FactoryOutput> {
 	let tsconfigFiles = [];
 	let typingsFiles = [];
 


### PR DESCRIPTION
This has bug me for a while. :p

Handle case where `typescriptOptions` is not set in `System.config({...})`.