### PR TITLE
Remove module resolution option from tsconfig

### DIFF
--- a/src/compiler-host.ts
+++ b/src/compiler-host.ts
@@ -21,6 +21,9 @@ export class CompilerHost implements ts.CompilerHost {
 		this._options.allowNonTsExtensions = (this._options.allowNonTsExtensions !== false);
 		this._options.skipDefaultLibCheck = (this._options.skipDefaultLibCheck !== false);
 		this._options.noResolve = true;
+		
+		// Remove module resolution option in order to prevent node module resolution from kicking in
+		delete this._options.moduleResolution;
 
 		this._files = {}; //new Map<string, ts.SourceFile>();
 		this._fileResMaps = {}; //new Map<string, any>();


### PR DESCRIPTION
TS 1.6 adds the ability for NodeJS style module resolution to be enabled via tsconfig.json. Many editors have this enabled by default, but it doesn't make any sense in the context of a JSPM plugin. Quick fix is for `moduleResolution` from tsconfig options to be ignored.