### PR TITLE
Fix source-maps.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -37,11 +37,7 @@ export function translate(load: Module): Promise<string> {
             load.source = result.js;
          
          if (result.sourceMap) {
-            if (this.transpiler && this.transpiler.indexOf("babel") >= 0)
-               load.metadata.sourceMap = JSON.parse(result.sourceMap);
-            else
-               load.metadata.sourceMap = result.sourceMap;
-         }
+            load.metadata.sourceMap = result.sourceMap;
          
          if (host.options.module === ts.ModuleKind.System)
             load.metadata.format = 'register';


### PR DESCRIPTION
Hi.
Thank you for this cool plugin.
I found strange behavior of source-maps, in systemjs(0.19.17 Standard) with babel transpiler.
So I decode inserted base64 encoded source-maps, and that result is '[object Object]'.
I think JSON.parse is not necessary any more.

Sorry If other version has some problem, because I test only systemjs(0.19.17 Standard with babel  transpiler).

Thanks.