### PR TITLE
support typings for any extension

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -124,13 +124,11 @@ export class Resolver {
 
 		const address = await this._resolve(importName, sourceName);
 
-		if (isJavaScript(address)) {
-			const atTypeAddress = await this.lookupAtType(importName, sourceName);
-			if (atTypeAddress) return atTypeAddress;
+		const atTypeAddress = await this.lookupAtType(importName, sourceName);
+		if (atTypeAddress) return atTypeAddress;
 
-			const typingAddress = await this.lookupTyping(importName, sourceName, address);
-			if (typingAddress) return typingAddress;
-		}
+		const typingAddress = await this.lookupTyping(importName, sourceName, address);
+		if (typingAddress) return typingAddress;
 
 		return address;
    }


### PR DESCRIPTION
I always use `.d.ts` files for my `css` along with `css-modules`, for example. I don't see a reason for this restriction.