### PR TITLE
Configurable support for file extension fall back

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -164,18 +164,38 @@ System.register(["typescript"], function (exports_1, context_1) {
         });
         return __global.tsfactory;
     }
+    function tryExtensions(load, remaining) {
+        remaining = remaining.slice();
+        return new Promise(function (resolve, reject) {
+            if (remaining.length == 0) {
+                return load.address;
+            }
+            var originalExtensionLocation = load.address.lastIndexOf(".");
+            var originalExtension = load.address.slice(originalExtensionLocation + 1);
+            var extensionLess = load.address.slice(0, originalExtensionLocation);
+            var originalRemainingIndex = remaining.indexOf(originalExtension);
+            var extensionToTry;
+            if (originalRemainingIndex >= 0) {
+                remaining.splice(originalRemainingIndex, 1);
+                extensionToTry = originalExtension;
+            }
+            else {
+                extensionToTry = remaining.shift();
+            }
+            var addressToTry = extensionLess + "." + extensionToTry;
+            resolve(_fetch(addressToTry).then(function (to) { return addressToTry; }).catch(function (to) { return tryExtensions(load, remaining); }));
+        });
+    }
     function locate(load) {
-        if (/((\.ts)|(\.tsx)|(\.jsx))$/i.test(load.address)) {
-            return _fetch(load.address).then(function (to) { return load.address; }).catch(function (to) {
-                return locate({ address: load.address
-                        .replace(/\.js$/i, ".jsx")
-                        .replace(/\.tsx$/i, ".js")
-                        .replace(/\.ts$/i, ".tsx")
-                });
-            });
-        }
-        else
-            return load.address;
+        factory = factory || getFactory();
+        return factory.then(function (_a) {
+            var transpiler = _a.transpiler, resolver = _a.resolver, typeChecker = _a.typeChecker, host = _a.host;
+            if (host.options.fileExtensions && Array.isArray(host.options.fileExtensions) && host.options.fileExtensions.length > 1) {
+                return tryExtensions(load, host.options.fileExtensions);
+            }
+            else
+                return Promise.resolve(load.address);
+        });
     }
     function translate(load) {
         var loader = this;
@@ -277,8 +297,6 @@ System.register(["typescript"], function (exports_1, context_1) {
             normalized = stripDoubleExtension(normalized);
             logger.debug("resolved " + normalized + " (" + parent + " -> " + dep + ")");
             return typescript_1.normalizePath(normalized);
-        }).then(function (normalized) {
-            return _fetch(normalized).then(function (to) { return normalized; }).catch(function (to) { return normalized.replace(".ts", ".tsx"); });
         });
     }
     function _fetch(address) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -168,7 +168,8 @@ System.register(["typescript"], function (exports_1, context_1) {
         remaining = remaining.slice();
         return new Promise(function (resolve, reject) {
             if (remaining.length == 0) {
-                return load.address;
+                resolve(load.address);
+                return;
             }
             var originalExtensionLocation = load.address.lastIndexOf(".");
             var originalExtension = load.address.slice(originalExtensionLocation + 1);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -164,6 +164,19 @@ System.register(["typescript"], function (exports_1, context_1) {
         });
         return __global.tsfactory;
     }
+    function locate(load) {
+        if (/((\.ts)|(\.tsx)|(\.jsx))$/i.test(load.address)) {
+            return _fetch(load.address).then(function (to) { return load.address; }).catch(function (to) {
+                return locate({ address: load.address
+                        .replace(/\.js$/i, ".jsx")
+                        .replace(/\.tsx$/i, ".js")
+                        .replace(/\.ts$/i, ".tsx")
+                });
+            });
+        }
+        else
+            return load.address;
+    }
     function translate(load) {
         var loader = this;
         logger.debug("systemjs translating " + load.address);
@@ -264,6 +277,8 @@ System.register(["typescript"], function (exports_1, context_1) {
             normalized = stripDoubleExtension(normalized);
             logger.debug("resolved " + normalized + " (" + parent + " -> " + dep + ")");
             return typescript_1.normalizePath(normalized);
+        }).then(function (normalized) {
+            return _fetch(normalized).then(function (to) { return normalized; }).catch(function (to) { return normalized.replace(".ts", ".tsx"); });
         });
     }
     function _fetch(address) {
@@ -891,6 +906,7 @@ System.register(["typescript"], function (exports_1, context_1) {
             logger$1 = new Logger({ debug: false });
             logger = new Logger({ debug: false });
             factory = null;
+            exports_1("locate", locate);
             exports_1("translate", translate);
             exports_1("instantiate", instantiate);
             exports_1("bundle", bundle);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -19,15 +19,37 @@ function getFactory() {
 	return __global.tsfactory;
 }
 
+function tryExtensions(load, remaining): Promise<string> {
+      //try each file extension, but try the load.address's file extension first, then the remaining file extensions in order
+      remaining = remaining.slice();
+      return new Promise((resolve,reject)=>{
+            if(remaining.length == 0) {
+                  return load.address;
+            }
+            var originalExtensionLocation = load.address.lastIndexOf(".");
+            var originalExtension = load.address.slice(originalExtensionLocation + 1);
+            var extensionLess = load.address.slice(0,originalExtensionLocation);
+            var originalRemainingIndex = remaining.indexOf(originalExtension);
+            var extensionToTry;
+            if(originalRemainingIndex >= 0) {
+                  remaining.splice(originalRemainingIndex,1);
+                  extensionToTry = originalExtension;
+            } else {
+                  extensionToTry = remaining.shift();
+            }
+            var addressToTry = extensionLess + "." + extensionToTry;
+            resolve(_fetch(addressToTry).then(to=>addressToTry).catch(to=>tryExtensions(load,remaining)))
+      })
+}
+
 export function locate(load) : Promise<string> {
-      // tries tsx if ts failed, then tries jsx if ts failed, then tries js if jsx failed
-      if(/((\.ts)|(\.tsx)|(\.jsx))$/i.test(load.address)){
-            return _fetch(load.address).then(to=>load.address).catch(to=>locate({address:load.address
-                  .replace(/\.js$/i,".jsx")
-                  .replace(/\.tsx$/i,".js")
-                  .replace(/\.ts$/i,".tsx")
-            }))
-      } else return load.address;
+      // if the user has set the fileExtensions option, figure out the real address of the file we are looking for
+      factory = factory || getFactory();
+      return factory.then(({transpiler, resolver, typeChecker, host}) => {
+            if(host.options.fileExtensions && Array.isArray(host.options.fileExtensions) && host.options.fileExtensions.length > 1){
+                  return tryExtensions(load, host.options.fileExtensions)
+            } else return Promise.resolve(load.address);
+      })
 }
 
 /*
@@ -162,9 +184,7 @@ function _resolve(dep: string, parent: string): Promise<string> {
 
          logger.debug(`resolved ${normalized} (${parent} -> ${dep})`);
          return (ts as any).normalizePath(normalized);
-      }).then(normalized => {
-        return _fetch(normalized).then(to=>normalized).catch(to=>normalized.replace(".ts",".tsx"))    
-      });
+      })
 }
 
 /*

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -19,6 +19,17 @@ function getFactory() {
 	return __global.tsfactory;
 }
 
+export function locate(load) : Promise<string> {
+      // tries tsx if ts failed, then tries jsx if ts failed, then tries js if jsx failed
+      if(/((\.ts)|(\.tsx)|(\.jsx))$/i.test(load.address)){
+            return _fetch(load.address).then(to=>load.address).catch(to=>locate({address:load.address
+                  .replace(/\.js$/i,".jsx")
+                  .replace(/\.tsx$/i,".js")
+                  .replace(/\.ts$/i,".tsx")
+            }))
+      } else return load.address;
+}
+
 /*
  * load.name
  * load.address
@@ -151,6 +162,8 @@ function _resolve(dep: string, parent: string): Promise<string> {
 
          logger.debug(`resolved ${normalized} (${parent} -> ${dep})`);
          return (ts as any).normalizePath(normalized);
+      }).then(normalized => {
+        return _fetch(normalized).then(to=>normalized).catch(to=>normalized.replace(".ts",".tsx"))    
       });
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,7 +24,8 @@ function tryExtensions(load, remaining): Promise<string> {
       remaining = remaining.slice();
       return new Promise((resolve,reject)=>{
             if(remaining.length == 0) {
-                  return load.address;
+                  resolve(load.address);
+                  return;
             }
             var originalExtensionLocation = load.address.lastIndexOf(".");
             var originalExtension = load.address.slice(originalExtensionLocation + 1);


### PR DESCRIPTION
This change adds configurable support for trying multiple file extensions when importing.
```
  typescriptOptions: {
    "fileExtensions": ["ts","tsx","jsx","js","json"]
  },
```
If the original extension that SystemJS asked for exists in the list, we try that first.  Otherwise, we try each extension in order until we find the file.  If we fail to find the file, we go ahead and return the original address to the missing file, like before.


