### PR TITLE
support "jsx":"preserve"

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,6 +1,93 @@
 System.register(["typescript"], function (exports_1, context_1) {
     "use strict";
     var __moduleName = context_1 && context_1.id;
+    function __awaiter(thisArg, _arguments, P, generator) {
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try {
+                step(generator.next(value));
+            }
+            catch (e) {
+                reject(e);
+            } }
+            function rejected(value) { try {
+                step(generator["throw"](value));
+            }
+            catch (e) {
+                reject(e);
+            } }
+            function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments)).next());
+        });
+    }
+    function __generator(thisArg, body) {
+        var _ = { label: 0, sent: function () { if (t[0] & 1)
+                throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t;
+        return { next: verb(0), "throw": verb(1), "return": verb(2) };
+        function verb(n) { return function (v) { return step([n, v]); }; }
+        function step(op) {
+            if (f)
+                throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done)
+                        return t;
+                    if (y = 0, t)
+                        op = [0, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2])
+                                _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                }
+                catch (e) {
+                    op = [6, e];
+                    y = 0;
+                }
+                finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5)
+                throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    }
     function isAbsolute(filename) {
         return (filename[0] === '/');
     }
@@ -15,6 +102,9 @@ System.register(["typescript"], function (exports_1, context_1) {
     }
     function isJavaScript(filename) {
         return javascriptRegex.test(filename);
+    }
+    function isJSX(filename) {
+        return jsxRegex.test(filename);
     }
     function isSourceMap(filename) {
         return mapRegex.test(filename);
@@ -204,6 +294,7 @@ System.register(["typescript"], function (exports_1, context_1) {
                 return Promise.resolve(load.source);
         });
     }
+    exports_1("translate", translate);
     function instantiate(load, systemInstantiate) {
         return factory.then(function (_a) {
             var typeChecker = _a.typeChecker, resolver = _a.resolver, host = _a.host;
@@ -218,6 +309,7 @@ System.register(["typescript"], function (exports_1, context_1) {
             });
         });
     }
+    exports_1("instantiate", instantiate);
     function typeCheck(load) {
         return factory.then(function (_a) {
             var typeChecker = _a.typeChecker, resolver = _a.resolver, host = _a.host;
@@ -253,6 +345,7 @@ System.register(["typescript"], function (exports_1, context_1) {
             return [];
         });
     }
+    exports_1("bundle", bundle);
     function validateOptions(options) {
         if ((options.module != typescript_1.ModuleKind.System) && (options.module != typescript_1.ModuleKind.ES2015)) {
             logger.warn("transpiling to " + typescript_1.ModuleKind[options.module] + ", consider setting module: \"system\" in typescriptOptions to transpile directly to System.register format");
@@ -284,7 +377,7 @@ System.register(["typescript"], function (exports_1, context_1) {
             return metadata;
         });
     }
-    var typescript_1, Logger, __awaiter, __generator, typescriptRegex, javascriptRegex, mapRegex, declarationRegex, htmlRegex, convertRegex, logger$2, HTML_MODULE, CompilerHost, logger$3, Transpiler, logger$4, Resolver, logger$5, TypeChecker, logger$1, logger, factory;
+    var typescript_1, Logger, typescriptRegex, javascriptRegex, jsxRegex, mapRegex, declarationRegex, htmlRegex, convertRegex, logger$2, HTML_MODULE, CompilerHost, logger$3, Transpiler, logger$4, Resolver, logger$5, TypeChecker, logger$1, logger, factory;
     return {
         setters: [
             function (typescript_1_1) {
@@ -313,95 +406,9 @@ System.register(["typescript"], function (exports_1, context_1) {
                 };
                 return Logger;
             }());
-            __awaiter = function (thisArg, _arguments, P, generator) {
-                return new (P || (P = Promise))(function (resolve, reject) {
-                    function fulfilled(value) { try {
-                        step(generator.next(value));
-                    }
-                    catch (e) {
-                        reject(e);
-                    } }
-                    function rejected(value) { try {
-                        step(generator["throw"](value));
-                    }
-                    catch (e) {
-                        reject(e);
-                    } }
-                    function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-                    step((generator = generator.apply(thisArg, _arguments)).next());
-                });
-            };
-            __generator = function (thisArg, body) {
-                var _ = { label: 0, sent: function () { if (t[0] & 1)
-                        throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t;
-                return { next: verb(0), "throw": verb(1), "return": verb(2) };
-                function verb(n) { return function (v) { return step([n, v]); }; }
-                function step(op) {
-                    if (f)
-                        throw new TypeError("Generator is already executing.");
-                    while (_)
-                        try {
-                            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done)
-                                return t;
-                            if (y = 0, t)
-                                op = [0, t.value];
-                            switch (op[0]) {
-                                case 0:
-                                case 1:
-                                    t = op;
-                                    break;
-                                case 4:
-                                    _.label++;
-                                    return { value: op[1], done: false };
-                                case 5:
-                                    _.label++;
-                                    y = op[1];
-                                    op = [0];
-                                    continue;
-                                case 7:
-                                    op = _.ops.pop();
-                                    _.trys.pop();
-                                    continue;
-                                default:
-                                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) {
-                                        _ = 0;
-                                        continue;
-                                    }
-                                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
-                                        _.label = op[1];
-                                        break;
-                                    }
-                                    if (op[0] === 6 && _.label < t[1]) {
-                                        _.label = t[1];
-                                        t = op;
-                                        break;
-                                    }
-                                    if (t && _.label < t[2]) {
-                                        _.label = t[2];
-                                        _.ops.push(op);
-                                        break;
-                                    }
-                                    if (t[2])
-                                        _.ops.pop();
-                                    _.trys.pop();
-                                    continue;
-                            }
-                            op = body.call(thisArg, _);
-                        }
-                        catch (e) {
-                            op = [6, e];
-                            y = 0;
-                        }
-                        finally {
-                            f = t = 0;
-                        }
-                    if (op[0] & 5)
-                        throw op[1];
-                    return { value: op[0] ? op[1] : void 0, done: true };
-                }
-            };
             typescriptRegex = /\.tsx?$/i;
             javascriptRegex = /\.js$/i;
+            jsxRegex = /\.jsx$/i;
             mapRegex = /\.map$/i;
             declarationRegex = /\.d\.tsx?$/i;
             htmlRegex = /\.html$/i;
@@ -607,7 +614,7 @@ System.register(["typescript"], function (exports_1, context_1) {
                         var jstext_1 = undefined;
                         var maptext_1 = undefined;
                         var emitResult = program.emit(undefined, function (outputName, output) {
-                            if (isJavaScript(outputName))
+                            if (isJavaScript(outputName) || isJSX(outputName))
                                 jstext_1 = output.slice(0, output.lastIndexOf("//#"));
                             else if (isSourceMap(outputName))
                                 maptext_1 = output;
@@ -894,9 +901,6 @@ System.register(["typescript"], function (exports_1, context_1) {
             logger$1 = new Logger({ debug: false });
             logger = new Logger({ debug: false });
             factory = null;
-            exports_1("translate", translate);
-            exports_1("instantiate", instantiate);
-            exports_1("bundle", bundle);
         }
     };
 });

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -1,7 +1,7 @@
 /* */
 import * as ts from 'typescript';
 import {CompilerHost, CombinedOptions, TranspileResult} from './compiler-host';
-import {isJavaScript, isSourceMap, hasError} from './utils';
+import {isJavaScript, isJSX, isSourceMap, hasError} from './utils';
 import Logger from './logger';
 
 const logger = new Logger({ debug: false });
@@ -59,7 +59,7 @@ export class Transpiler {
 
          // Emit
          const emitResult = program.emit(undefined, (outputName, output) => {
-            if (isJavaScript(outputName))
+            if (isJavaScript(outputName) || isJSX(outputName))
                jstext = output.slice(0, output.lastIndexOf("//#")); // remove sourceMappingURL
             else if (isSourceMap(outputName))
                maptext = output;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,11 @@ export function isJavaScript(filename: string) {
 	return javascriptRegex.test(filename);
 }
 
+const jsxRegex = /\.jsx$/i;
+export function isJSX(filename: string) {
+	return jsxRegex.test(filename)
+}
+
 const mapRegex = /\.map$/i;
 export function isSourceMap(filename: string) {
 	return mapRegex.test(filename);


### PR DESCRIPTION
All I needed to do was pass it as if it was JavaScript, and babel had no problem with it.
For some reason, my bundle output has some extra cruft-- don't know what that is all about.