### PR TITLE
tolerate ModuleKind.ESNext

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/frankwallis/plugin-typescript.git"
   },
   "peerDependencies": {
-    "typescript": "^2.0.0"
+    "typescript": "^2.4.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",
@@ -46,7 +46,7 @@
     "sinon": "^1.17.7",
     "ts-node": "^2.0.0",
     "tslib": "^1.4.0",
-    "typescript": "^2.2.0"
+    "typescript": "^2.4.0"
   },
   "scripts": {
     "bundle": "tsc && rollup -c && tsc ./tmp/plugin.js -m system -lib es6 -allowJs -allowUnreachableCode -removeComments -outDir ./lib",
@@ -62,7 +62,7 @@
     "registry": "github",
     "name": "frankwallis/plugin-typescript",
     "peerDependencies": {
-      "typescript": "npm:typescript@^2.0.0"
+      "typescript": "npm:typescript@^2.4.0"
     },
     "directories": {
       "lib": "lib",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup": "^0.41.4",
     "rollup-plugin-includepaths": "^0.2.1",
     "sinon": "^1.17.7",
-    "ts-node": "^2.0.0",
+    "ts-node": "^3.0.0",
     "tslib": "^1.4.0",
     "typescript": "^2.4.0"
   },

--- a/src/resolve-options.ts
+++ b/src/resolve-options.ts
@@ -90,7 +90,7 @@ function getEnum(enumValue: any, enumType: any, defaultValue: number): number {
 function validateOptions(options: CombinedOptions) {
    /* The only time you don't want to output in 'm format is when you are using rollup or babel
       downstream to compile es6 output (e.g. for async/await support) */
-	if ((options.module != ts.ModuleKind.System) && (options.module != ts.ModuleKind.ES2015)) {
+	if ((options.module !== ts.ModuleKind.System) && (options.module !== ts.ModuleKind.ES2015) && (options.module !== ts.ModuleKind.ESNext)) {
 		logger.warn(`transpiling to ${ts.ModuleKind[options.module]}, consider setting module: "system" in typescriptOptions to transpile directly to System.register format`)
 	}
 

--- a/test/builder-spec.ts
+++ b/test/builder-spec.ts
@@ -234,13 +234,24 @@ describe('Builder', () => {
 		})
 	})
 
-	it('supports dynamic import when outputting esnext modules', async () => {
+	it('supports dynamic import when bundling to esnext modules', async () => {
 		const config = defaultConfig()
 		config.map["testsrc"] = "test/fixtures-es6/plugin/dynamic"
 		config.typescriptOptions.module = "esnext"
-		config.typescriptOptions.target = "esnext"
+		config.typescriptOptions.target = "es5"
 		builder.config(config)
-		const result = await builder.buildStatic('testsrc', {}) as {source: string}
+		const result = await builder.bundle('testsrc', {})
+		console.log(result.source)
+		result.source.should.contain('_context.import(\'')
+	})
+
+	it('supports dynamic import when building to esnext modules', async () => {
+		const config = defaultConfig()
+		config.map["testsrc"] = "test/fixtures-es6/plugin/dynamic"
+		config.typescriptOptions.module = "esnext"
+		config.typescriptOptions.target = "es5"
+		builder.config(config)
+		const result = await builder.buildStatic('testsrc', {})
 		console.log(result.source)
 		result.source.should.contain('_context.import(\'')
 	})

--- a/test/builder-spec.ts
+++ b/test/builder-spec.ts
@@ -7,7 +7,15 @@ chai.use(chaiAsPromised)
 const should = chai.should()
 
 describe('Builder', () => {
-	let builder = null
+	interface Builder {
+		builderStatic(build: string, options?: object): Promise<{source: string}>
+		reset(): void
+		bundle(bundleSpec: string, options?: object): Promise<{source: string}>
+		buildStatic(bundleSpec: string, options?: object): Promise<{source: string}>
+		config<T extends SystemJSLoader.Config | {transpiler}>(config?: T): void
+	}
+
+	let builder: Builder = null
 
 	beforeEach(() => {
 		global['tsHost'] = undefined
@@ -26,7 +34,7 @@ describe('Builder', () => {
 				"jsx": "react",
 				"noImplicitAny": false,
 				"tsconfig": false
-			} as any,
+			},
 			packages: {
 				"testsrc": {
 					"main": "index",
@@ -224,5 +232,16 @@ describe('Builder', () => {
 			result.source.indexOf('counter.imported += 1').should.be.above(-1);
 			result.source.indexOf('counter.elided += 1').should.be.equal(-1);
 		})
+	})
+
+	it('supports dynamic import when outputting esnext modules', async () => {
+		const config = defaultConfig()
+		config.map["testsrc"] = "test/fixtures-es6/plugin/dynamic"
+		config.typescriptOptions.module = "esnext"
+		config.typescriptOptions.target = "esnext"
+		builder.config(config)
+		const result = await builder.buildStatic('testsrc', {}) as {source: string}
+		console.log(result.source)
+		result.source.should.contain('_context.import(\'')
 	})
 })

--- a/test/fixtures-es6/plugin/dynamic/dynamic-dependency.ts
+++ b/test/fixtures-es6/plugin/dynamic/dynamic-dependency.ts
@@ -1,0 +1,1 @@
+export default 1

--- a/test/fixtures-es6/plugin/dynamic/index.ts
+++ b/test/fixtures-es6/plugin/dynamic/index.ts
@@ -1,0 +1,3 @@
+export default function () {
+	return import('./dynamic-dependency')
+}

--- a/test/plugin-spec.ts
+++ b/test/plugin-spec.ts
@@ -1,3 +1,4 @@
+import os = require('os')
 import chai = require('chai')
 import chaiAsPromised = require('chai-as-promised')
 import * as ts from 'typescript'
@@ -113,7 +114,7 @@ describe('Plugin', () => {
 			System.config(config)
 			const mod = await System.import('testsrc')
 				.should.be.fulfilled
-			mod.default.should.equal('<div>hello</div>\n')
+			mod.default.should.equal('<div>hello</div>' + os.EOL)
 		})
 
 		it('compiles js commonjs files', async () => {


### PR DESCRIPTION
As described in #208, this change supports recognizes `ModuleKind.ESNext`, a superset of `ModuleKind.ES2015` introduced in TypeScript 2.4.0.

It also updates typescript as necessary and updates ts-node (previous version did not detect `@types` packages referenced by unit tests correctly).