### PR TITLE
Guard `options.lib` from undefined

### DIFF
--- a/src/compiler-host.ts
+++ b/src/compiler-host.ts
@@ -27,7 +27,7 @@ export class CompilerHost implements ts.CompilerHost {
 	}
 
 	public getDefaultLibFilePaths(options: ts.CompilerOptions): string[] {
-		return options.lib.map(libName => `typescript/lib/lib.${libName}.d.ts`)
+		return options.lib ? options.lib.map(libName => `typescript/lib/lib.${libName}.d.ts`) : []
 	}
 
 	public useCaseSensitiveFileNames(): boolean {


### PR DESCRIPTION
Fixes #211 
